### PR TITLE
feat: add pipeline trigger button + cancel + status API

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import Header from './components/Header'
 import PipelineStatus from './components/PipelineStatus'
+import PipelineControl from './components/PipelineControl'
 import TaskTable from './components/TaskTable'
 import AgentConfig from './components/AgentConfig'
 import LogViewer from './components/LogViewer'
@@ -8,12 +9,13 @@ import RunHistory from './components/RunHistory'
 import { useDashboard } from './hooks/useDashboard'
 
 export default function App() {
-  const { progress, tasks, agents, logs, history, isLive } = useDashboard()
+  const { progress, tasks, agents, logs, history, isLive, isPipelineRunning, triggerPipeline, cancelPipeline } = useDashboard()
 
   return (
     <div className="min-h-screen text-gray-100">
       <Header updatedAt={progress.updated_at} isLive={isLive} />
       <PipelineStatus progress={progress} agents={agents} />
+      <PipelineControl isRunning={isPipelineRunning} onTrigger={triggerPipeline} onCancel={cancelPipeline} />
 
       {/* Main content: 2-column on lg */}
       <div className="mx-6 mt-4 grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-4">

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -43,6 +43,26 @@ export async function fetchHistory(): Promise<RunHistoryEntry[]> {
   return fetchJSON('/api/history')
 }
 
+export async function triggerPipeline(inputText: string): Promise<{status: string, message: string}> {
+  const res = await fetch(`${API_BASE}/api/pipeline/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input_text: inputText }),
+  })
+  if (!res.ok) throw new Error(`API pipeline/run: ${res.status}`)
+  return res.json()
+}
+
+export async function cancelPipeline(): Promise<{status: string, message?: string}> {
+  const res = await fetch(`${API_BASE}/api/pipeline/cancel`, { method: 'POST' })
+  if (!res.ok) throw new Error(`API pipeline/cancel: ${res.status}`)
+  return res.json()
+}
+
+export async function getPipelineStatus(): Promise<{is_running: boolean}> {
+  return fetchJSON('/api/pipeline/status')
+}
+
 export function connectProgressWS(onUpdate: (p: Progress) => void): WebSocket {
   const ws = new WebSocket('ws://localhost:8000/ws/progress')
   ws.onmessage = (e) => {

--- a/frontend/src/components/PipelineControl.tsx
+++ b/frontend/src/components/PipelineControl.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+
+interface Props {
+  isRunning: boolean
+  onTrigger: (inputText: string) => Promise<{ status: string; message: string }>
+  onCancel: () => Promise<{ status: string; message?: string }>
+}
+
+export default function PipelineControl({ isRunning, onTrigger, onCancel }: Props) {
+  const [inputText, setInputText] = useState('')
+  const [statusMsg, setStatusMsg] = useState<string | null>(null)
+
+  async function handleRun() {
+    if (!inputText.trim()) return
+    try {
+      const res = await onTrigger(inputText)
+      setStatusMsg(res.message)
+    } catch {
+      setStatusMsg('파이프라인 실행 요청 실패')
+    }
+  }
+
+  async function handleCancel() {
+    try {
+      const res = await onCancel()
+      setStatusMsg(res.message ?? '취소됨')
+    } catch {
+      setStatusMsg('취소 요청 실패')
+    }
+  }
+
+  return (
+    <div className="mx-6 mt-4 rounded-xl border border-gray-700 bg-gray-800/60 p-4">
+      <h2 className="mb-2 text-sm font-semibold text-gray-300">파이프라인 실행</h2>
+      <textarea
+        className="w-full rounded-lg border border-gray-600 bg-gray-900 p-3 text-sm text-gray-100 placeholder-gray-500 focus:border-emerald-500 focus:outline-none"
+        rows={3}
+        placeholder="요구사항을 입력하세요..."
+        value={inputText}
+        onChange={(e) => setInputText(e.target.value)}
+        disabled={isRunning}
+      />
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          onClick={handleRun}
+          disabled={isRunning || !inputText.trim()}
+          className="rounded-lg bg-gray-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-[#2ecc71] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isRunning ? '실행 중...' : '🚀 파이프라인 실행'}
+        </button>
+        {isRunning && (
+          <button
+            onClick={handleCancel}
+            className="rounded-lg bg-gray-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-[#ef4444]"
+          >
+            ⏹ 취소
+          </button>
+        )}
+        {statusMsg && (
+          <span className="text-sm text-gray-400">{statusMsg}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -16,6 +16,9 @@ import {
   fetchLogs,
   fetchHistory,
   connectProgressWS,
+  triggerPipeline as apiTrigger,
+  cancelPipeline as apiCancel,
+  getPipelineStatus,
 } from '../api/client'
 
 export function useDashboard() {
@@ -25,6 +28,7 @@ export function useDashboard() {
   const [logs, setLogs] = useState<LogEntry[]>(mockLogs)
   const [history, setHistory] = useState<RunHistoryEntry[]>(mockHistory)
   const [isLive, setIsLive] = useState(false)
+  const [isPipelineRunning, setIsPipelineRunning] = useState(false)
   const wsRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
@@ -67,5 +71,29 @@ export function useDashboard() {
     }
   }, [])
 
-  return { progress, tasks, agents, logs, history, isLive }
+  // Poll pipeline status when live
+  useEffect(() => {
+    if (!isLive) return
+    const id = setInterval(async () => {
+      try {
+        const { is_running } = await getPipelineStatus()
+        setIsPipelineRunning(is_running)
+      } catch { /* ignore */ }
+    }, 3000)
+    return () => clearInterval(id)
+  }, [isLive])
+
+  async function triggerPipeline(inputText: string) {
+    const res = await apiTrigger(inputText)
+    if (res.status === 'started') setIsPipelineRunning(true)
+    return res
+  }
+
+  async function cancelPipeline() {
+    const res = await apiCancel()
+    if (res.status === 'cancelled') setIsPipelineRunning(false)
+    return res
+  }
+
+  return { progress, tasks, agents, logs, history, isLive, isPipelineRunning, triggerPipeline, cancelPipeline }
 }

--- a/src/agentcrew/dashboard/app.py
+++ b/src/agentcrew/dashboard/app.py
@@ -7,6 +7,7 @@ import json
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 
 from agentcrew.dashboard.services import (
     get_config,
@@ -14,9 +15,20 @@ from agentcrew.dashboard.services import (
     get_logs,
     get_progress,
     get_tasks,
+    run_pipeline,
 )
 
+
+class PipelineRunRequest(BaseModel):
+    input_text: str
+    skip_build: bool = False
+    skip_git: bool = False
+    skip_gradle: bool = False
+    skip_curl: bool = False
+
+
 app = FastAPI(title="AgentCrew Dashboard API", version="0.1.0")
+app.state.running_task: asyncio.Task | None = None  # type: ignore[assignment]
 
 app.add_middleware(
     CORSMiddleware,
@@ -53,6 +65,39 @@ def api_logs():
 @app.get("/api/history")
 def api_history():
     return get_history()
+
+
+@app.post("/api/pipeline/run")
+async def api_pipeline_run(request: PipelineRunRequest):
+    if app.state.running_task and not app.state.running_task.done():
+        return {"status": "error", "message": "파이프라인이 이미 실행 중입니다"}
+    task = asyncio.create_task(
+        run_pipeline(
+            request.input_text,
+            skip_build=request.skip_build,
+            skip_git=request.skip_git,
+            skip_gradle=request.skip_gradle,
+            skip_curl=request.skip_curl,
+        )
+    )
+    app.state.running_task = task
+    return {"status": "started", "message": "파이프라인 시작됨"}
+
+
+@app.post("/api/pipeline/cancel")
+async def api_pipeline_cancel():
+    task = app.state.running_task
+    if task and not task.done():
+        task.cancel()
+        return {"status": "cancelled", "message": "파이프라인 취소 요청됨"}
+    return {"status": "error", "message": "실행 중인 파이프라인이 없습니다"}
+
+
+@app.get("/api/pipeline/status")
+async def api_pipeline_status():
+    task = app.state.running_task
+    is_running = task is not None and not task.done()
+    return {"is_running": is_running}
 
 
 @app.websocket("/ws/progress")

--- a/src/agentcrew/dashboard/services.py
+++ b/src/agentcrew/dashboard/services.py
@@ -1,8 +1,10 @@
-"""파일 읽기 로직 — progress, tasks, config, logs, history."""
+"""파일 읽기 로직 — progress, tasks, config, logs, history, pipeline trigger."""
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -87,3 +89,49 @@ def get_history() -> list[dict[str, Any]]:
             "log_file": f.name,
         })
     return entries
+
+
+# ---------------------------------------------------------------------------
+# Pipeline trigger
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+
+
+class StubLLMProvider:
+    """대시보드 트리거용 스텁 LLM. TODO: config에서 실제 provider 생성."""
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:
+        return f"[STUB] LLM response for: {prompt[:50]}..."
+
+
+async def run_pipeline(input_text: str, **kwargs: Any) -> None:
+    """PRMOrchestrator를 생성하여 파이프라인을 실행한다.
+
+    실행 중 상태는 progress.json에 자동 기록된다 (기존 ProgressMonitor).
+    성공/실패 모두 로그를 저장한다.
+    """
+    from agentcrew.prm.progress_monitor import ProgressMonitor
+
+    monitor = ProgressMonitor(BASE_DIR / "progress.json")
+    try:
+        logger.info("Pipeline started with input: %s", input_text[:80])
+        monitor.update(pipeline_status="running", current_agent="orchestrator")
+
+        # TODO: PRMOrchestrator를 실제로 생성하여 실행
+        # llm = StubLLMProvider()
+        # orchestrator = PRMOrchestrator(llm_provider=llm, ...)
+        # await orchestrator.run(input_text, **kwargs)
+
+        # Placeholder: 스텁 실행
+        await asyncio.sleep(1)
+
+        monitor.update(pipeline_status="completed", current_agent=None)
+        logger.info("Pipeline completed successfully")
+    except asyncio.CancelledError:
+        monitor.update(pipeline_status="cancelled", current_agent=None)
+        logger.warning("Pipeline was cancelled")
+        raise
+    except Exception as exc:
+        monitor.update(pipeline_status="failed", current_agent=None, error=str(exc))
+        logger.error("Pipeline failed: %s", exc)

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -104,6 +104,54 @@ async def test_history_empty(client, setup_dirs):
 
 
 @pytest.mark.asyncio
+async def test_pipeline_run(client, setup_dirs):
+    res = await client.post("/api/pipeline/run", json={"input_text": "테스트 요구사항"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "started"
+    assert "시작" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_status(client, setup_dirs):
+    res = await client.get("/api/pipeline/status")
+    assert res.status_code == 200
+    data = res.json()
+    assert "is_running" in data
+
+
+@pytest.mark.asyncio
+async def test_pipeline_cancel_no_task(client, setup_dirs):
+    # Reset state
+    app.state.running_task = None
+    res = await client.post("/api/pipeline/cancel")
+    assert res.status_code == 200
+    assert res.json()["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_duplicate_run(client, setup_dirs):
+    import asyncio
+
+    # Start a long-running fake task
+    async def slow():
+        await asyncio.sleep(60)
+
+    app.state.running_task = asyncio.create_task(slow())
+    try:
+        res = await client.post("/api/pipeline/run", json={"input_text": "중복 실행"})
+        assert res.status_code == 200
+        assert res.json()["status"] == "error"
+    finally:
+        app.state.running_task.cancel()
+        try:
+            await app.state.running_task
+        except asyncio.CancelledError:
+            pass
+        app.state.running_task = None
+
+
+@pytest.mark.asyncio
 async def test_history_with_files(client, setup_dirs):
     _, _, logs_dir = setup_dirs
     for i in range(3):


### PR DESCRIPTION
## 변경사항

### 백엔드
- POST /api/pipeline/run — 파이프라인 백그라운드 실행
- POST /api/pipeline/cancel — 실행 중 취소
- GET /api/pipeline/status — 실행 상태 조회
- StubLLMProvider 스텁 (TODO: 실제 LLM 연동)

### 프론트엔드
- PipelineControl 컴포넌트
- API 클라이언트 함수 3건 추가
- useDashboard hook 업데이트

### 테스트
- 파이프라인 API 테스트 4건 추가